### PR TITLE
fixes: removed prev. mongo volumes

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Starter application",
     "main": "server.js",
     "scripts": {
-        "docker": "docker-compose -f docker-compose.yaml up",
+        "docker": "docker compose down -v && docker-compose -f docker-compose.yaml up",
         "prepare": "husky install",
         "lint": "eslint server.js",
         "dev": "nodemon server.js",


### PR DESCRIPTION
The fix will delete all existing mongo volumes to avoid data duplication. This is needed to have a consistent data for all users.